### PR TITLE
Update _config_automation.yml and refresh-data.yaml to add a data fetching docker image

### DIFF
--- a/.github/workflows/refresh-data.yaml
+++ b/.github/workflows/refresh-data.yaml
@@ -32,6 +32,7 @@ jobs:
       toggle_googleforms: "${{ env.REFRESH_GOOGLEFORMS }}"
       toggle_slido: "${{ env.REFRESH_SLIDO }}"
       toggle_youtube: "${{ env.REFRESH_YOUTUBE }}"
+      data_image: "${{ env.DATA_IMAGE }}"
       rendering_docker_image: "${{ env.RENDERING_DOCKER_IMAGE }}"
       ### Inputs ###
       cran_packages: "${{ env.CRAN_PACKAGES }}"
@@ -46,7 +47,7 @@ jobs:
     needs: yaml-check
     runs-on: ubuntu-latest
     container:
-      image: ${{needs.yaml-check.outputs.rendering_docker_image}}
+      image: ${{needs.yaml-check.outputs.data_image}}
     if: ${{needs.yaml-check.outputs.toggle_calendly == 'yes'}}
 
     steps:
@@ -80,7 +81,7 @@ jobs:
     needs: yaml-check
     runs-on: ubuntu-latest
     container:
-      image: ${{needs.yaml-check.outputs.rendering_docker_image}}
+      image: ${{needs.yaml-check.outputs.data_image}}
     if: ${{needs.yaml-check.outputs.toggle_cran == 'yes'}}
 
     steps:
@@ -111,7 +112,7 @@ jobs:
     needs: yaml-check
     runs-on: ubuntu-latest
     container:
-      image: ${{needs.yaml-check.outputs.rendering_docker_image}}
+      image: ${{needs.yaml-check.outputs.data_image}}
     if: ${{needs.yaml-check.outputs.toggle_citations == 'yes'}}
 
     steps:
@@ -142,7 +143,7 @@ jobs:
     needs: yaml-check
     runs-on: ubuntu-latest
     container:
-      image: ${{needs.yaml-check.outputs.rendering_docker_image}}
+      image: ${{needs.yaml-check.outputs.data_image}}
     if: ${{needs.yaml-check.outputs.toggle_ga == 'yes'}}
 
     steps:
@@ -176,7 +177,7 @@ jobs:
     needs: yaml-check
     runs-on: ubuntu-latest
     container:
-      image: ${{needs.yaml-check.outputs.rendering_docker_image}}
+      image: ${{needs.yaml-check.outputs.data_image}}
     if: ${{needs.yaml-check.outputs.toggle_github == 'yes'}}
 
     steps:
@@ -207,7 +208,7 @@ jobs:
     needs: yaml-check
     runs-on: ubuntu-latest
     container:
-      image: ${{needs.yaml-check.outputs.rendering_docker_image}}
+      image: ${{needs.yaml-check.outputs.data_image}}
     if: ${{needs.yaml-check.outputs.toggle_googleforms == 'yes'}}
 
     steps:
@@ -239,7 +240,7 @@ jobs:
     needs: yaml-check
     runs-on: ubuntu-latest
     container:
-      image: ${{needs.yaml-check.outputs.rendering_docker_image}}
+      image: ${{needs.yaml-check.outputs.data_image}}
     if: ${{needs.yaml-check.outputs.toggle_slido == 'yes'}}
 
     steps:
@@ -271,7 +272,7 @@ jobs:
     needs: yaml-check
     runs-on: ubuntu-latest
     container:
-      image: ${{needs.yaml-check.outputs.rendering_docker_image}}
+      image: ${{needs.yaml-check.outputs.data_image}}
     if: ${{needs.yaml-check.outputs.toggle_youtube == 'yes'}}
 
     steps:

--- a/_config_automation.yml
+++ b/_config_automation.yml
@@ -75,3 +75,5 @@ render-website: rmd_web
 # What docker image should be used for rendering?
 # The default is cansav09/metricminer:main
 rendering-docker-image: 'jhudsl/base_ottr:main'
+# What docker image should be to get the data?
+data-image: 'cansav09/metricminer:main'


### PR DESCRIPTION
Adding a docker image specifically for refreshing data

Refresh data action is passing again for this branch: https://github.com/ottrproject/metricminer-dashboard/actions/runs/15052298700 (except for citations, see issue #3) 

And render website action is passing again for this branch: https://github.com/ottrproject/metricminer-dashboard/actions/runs/15052348748

I don't know if this is the preferred fix long term, so putting in an issue on the metricminer repo about adding curl to that docker image (https://github.com/ottrproject/metricminer/issues/4), or maybe we should create a docker image in ottr docker that uses base ottr as a base and installs metricminer? I'll put an issue in that repo too (https://github.com/ottrproject/ottr-docker/issues/5).

