### PR TITLE
Include current date in GitHub metrics processing

### DIFF
--- a/refresh-scripts/refresh-github.R
+++ b/refresh-scripts/refresh-github.R
@@ -62,7 +62,7 @@ if (yaml$data_dest == "github") {
     dplyr::filter(repo %in% yaml$github_repos)
 
   dplyr::bind_rows(old_gh_metrics, gh_metrics) %>% 
-    dplyr::distinct(select(., -current_date), .keep_all =  TRUE) %>% 
+    dplyr::distinct(select(., -current_date), .keep_all =  TRUE) %>%  #using .keep_all = TRUE to keep the current_date column in the output
     readr::write_tsv(file.path(folder_path, "github.tsv"))
   
   dplyr::bind_rows(old_gh_timecourse, gh_timecourse) %>% 

--- a/refresh-scripts/refresh-github.R
+++ b/refresh-scripts/refresh-github.R
@@ -29,7 +29,7 @@ auth_from_secret("github", token = Sys.getenv("METRICMINER_GITHUB_PAT"))
 gh_metrics <- get_multiple_repos_metrics(repo_names = yaml$github_repos) %>% 
                 mutate(current_date = today())
 gh_timecourse <- get_multiple_repos_metrics(repo_names = yaml$github_repos, time_course = TRUE) %>%
-                mutate(current_date = today())
+                dplyr::mutate(current_date = today())
 
 setup_folders(
   folder_path = folder_path,

--- a/refresh-scripts/refresh-github.R
+++ b/refresh-scripts/refresh-github.R
@@ -4,6 +4,7 @@
 
 library(metricminer)
 library(magrittr)
+library(lubridate)
 
 # Find .git root directory
 root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
@@ -25,8 +26,10 @@ auth_from_secret("google",
 auth_from_secret("github", token = Sys.getenv("METRICMINER_GITHUB_PAT"))
 
 # Read the data
-gh_metrics <- get_multiple_repos_metrics(repo_names = yaml$github_repos)
-gh_timecourse <- get_multiple_repos_metrics(repo_names = yaml$github_repos, time_course = TRUE)
+gh_metrics <- get_multiple_repos_metrics(repo_names = yaml$github_repos) %>% 
+                mutate(current_date = today())
+gh_timecourse <- get_multiple_repos_metrics(repo_names = yaml$github_repos, time_course = TRUE) %>%
+                mutate(current_date = today())
 
 setup_folders(
   folder_path = folder_path,
@@ -59,11 +62,11 @@ if (yaml$data_dest == "github") {
     dplyr::filter(repo %in% yaml$github_repos)
 
   dplyr::bind_rows(old_gh_metrics, gh_metrics) %>% 
-    dplyr::distinct() %>% 
+    dplyr::distinct(select(., -current_date), .keep_all =  TRUE) %>% 
     readr::write_tsv(file.path(folder_path, "github.tsv"))
   
   dplyr::bind_rows(old_gh_timecourse, gh_timecourse) %>% 
-    dplyr::distinct() %>% 
+    dplyr::distinct(select(., -current_date), .keep_all = TRUE) %>% 
     readr::write_tsv(file.path(folder_path, "github_timecourse.tsv"))
 }
 

--- a/refresh-scripts/refresh-github.R
+++ b/refresh-scripts/refresh-github.R
@@ -27,7 +27,7 @@ auth_from_secret("github", token = Sys.getenv("METRICMINER_GITHUB_PAT"))
 
 # Read the data
 gh_metrics <- get_multiple_repos_metrics(repo_names = yaml$github_repos) %>% 
-                mutate(current_date = today())
+                dplyr::mutate(current_date = today())
 gh_timecourse <- get_multiple_repos_metrics(repo_names = yaml$github_repos, time_course = TRUE) %>%
                 dplyr::mutate(current_date = today())
 


### PR DESCRIPTION
Because this refresh script is appending old data to new data, I've added current date to GitHub metrics and timecourse data. I've also edited the distinct function so that it will ignore the current date variable (but still write it out).

When I saw that each repo had multiple rows worth of data (for example: https://github.com/ottrproject/metricminer-dashboard/blob/main/metricminer_data/github/github.tsv), it was confusing to me, but adding the date that the data is from will help to clarify that for users.

